### PR TITLE
NT: update wp cli to latest version

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get clean && \
   apt-get install expect -y && \
   apt-get install vim -y
 
+# Update wp cli
+RUN wp cli update --yes
+
 # All further commands will be performed as the docker user.
 USER docker
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Docksal's version is behind and prints very verbose deprecation warnings on php 8.2