### PR TITLE
Support Drupal 11 SQLite version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,12 @@
 set -ex
 
 # Arguments: $1 CLI_VERSION
-docker build --build-arg CLI_VERSION=php"${1:-8.0}" -t phase2/docker-cli:php"${1:-8.0}" ./src
+CLI_VERSION=${1:-8.3}
+
+# Install SQLite 3.x for Drupal 11 testing if CLI version >= 8.3
+INSTALL_SQLITE=false
+if [ "$(echo "${CLI_VERSION} >= 8.3" | bc -l)" -eq 1 ]; then
+  INSTALL_SQLITE=true
+fi
+
+docker build --build-arg CLI_VERSION=php"$CLI_VERSION" --build-arg INSTALL_SQLITE="$INSTALL_SQLITE" -t phase2/docker-cli:php"$CLI_VERSION" ./src

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ CLI_VERSION=${1:-8.3}
 
 # Install SQLite 3.x for Drupal 11 testing if CLI version >= 8.3
 INSTALL_SQLITE=false
+# Use the `bc` calculator to compare the PHP version number.
 if [ "$(echo "${CLI_VERSION} >= 8.3" | bc -l)" -eq 1 ]; then
   INSTALL_SQLITE=true
 fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,7 +7,8 @@ FROM docksal/cli:${CLI_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG HELM_VERSION=v2.17.0
-# Args defined before the FROM directive are not available in the build stage.
+# Args defined before the FROM directive are not available in the build stage,
+# so cannot test CLI_VERSION directly here.
 ARG INSTALL_SQLITE=false
 
 # Install kubectl and helm client

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -39,15 +39,19 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-"$(uname -m)".zip -o "aws
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_"$(dpkg --print-architecture)".tar.gz -O - |\
   tar xz && mv yq_linux_"$(dpkg --print-architecture)" /usr/bin/yq
 
-# Upgrade SQLite for Drupal 11 testing.
+# Upgrade SQLite 3.x for Drupal 11 testing if CLI version >= 8.3
 # @see https://www.drupal.org/project/drupal/issues/3346338
 # @see https://github.com/docksal/service-cli/pull/327/files
-RUN set -xe; \
+# Use the `bc` calculator to compare the PHP version number, removing the `php` prefix.
+# Need to get sqlite3 from the Debian testing repository as the default version is too old.
+RUN if [ "$(echo "${CLI_VERSION#php} >= 8.3" | bc -l)" -eq 1 ]; then \
+  set -xe; \
   echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
   apt-get update >/dev/null; \
-  apt-get install -y -t testing sqlite3;\
+  apt-get install -y -t testing sqlite3; \
   # Cleanup
-  apt-get clean; rm -rf /var/lib/apt/lists/*
+  apt-get clean; rm -rf /var/lib/apt/lists/*; \
+fi
 
 # Install expect, vim
 RUN apt-get clean && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,6 +7,8 @@ FROM docksal/cli:${CLI_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG HELM_VERSION=v2.17.0
+# Args defined before the FROM directive are not available in the build stage.
+ARG INSTALL_SQLITE=false
 
 # Install kubectl and helm client
 RUN curl -o /usr/local/bin/kubectl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" && \
@@ -44,12 +46,11 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_"$(d
 # @see https://github.com/docksal/service-cli/pull/327/files
 # Use the `bc` calculator to compare the PHP version number, removing the `php` prefix.
 # Need to get sqlite3 from the Debian testing repository as the default version is too old.
-RUN if [ "$(echo "${CLI_VERSION#php} >= 8.3" | bc -l)" -eq 1 ]; then \
+RUN if [ "$INSTALL_SQLITE" = "true" ]; then \
   set -xe; \
   echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
   apt-get update >/dev/null; \
   apt-get install -y -t testing sqlite3; \
-  # Cleanup
   apt-get clean; rm -rf /var/lib/apt/lists/*; \
 fi
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -39,6 +39,16 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-"$(uname -m)".zip -o "aws
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_"$(dpkg --print-architecture)".tar.gz -O - |\
   tar xz && mv yq_linux_"$(dpkg --print-architecture)" /usr/bin/yq
 
+# Upgrade SQLite for Drupal 11 testing.
+# @see https://www.drupal.org/project/drupal/issues/3346338
+# @see https://github.com/docksal/service-cli/pull/327/files
+RUN set -xe; \
+  echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+  apt-get update >/dev/null; \
+  apt-get install -y -t testing sqlite3;\
+  # Cleanup
+  apt-get clean; rm -rf /var/lib/apt/lists/*
+
 # Install expect, vim
 RUN apt-get clean && \
   apt update && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -42,10 +42,9 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-"$(uname -m)".zip -o "aws
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_"$(dpkg --print-architecture)".tar.gz -O - |\
   tar xz && mv yq_linux_"$(dpkg --print-architecture)" /usr/bin/yq
 
-# Upgrade SQLite 3.x for Drupal 11 testing if CLI version >= 8.3
+# Upgrade SQLite 3.x if specified in the build args.
 # @see https://www.drupal.org/project/drupal/issues/3346338
 # @see https://github.com/docksal/service-cli/pull/327/files
-# Use the `bc` calculator to compare the PHP version number, removing the `php` prefix.
 # Need to get sqlite3 from the Debian testing repository as the default version is too old.
 RUN if [ "$INSTALL_SQLITE" = "true" ]; then \
   set -xe; \


### PR DESCRIPTION
This is a downstream fix of https://github.com/docksal/service-cli/pull/327

There's some talk of removing this version requirement in  https://www.drupal.org/project/drupal/issues/3346338 but until then, this is necessary for running pre-build Drupal tests (Kernel, and Functional).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added conditional SQLite3 installation for Drupal 11 testing support based on the PHP CLI version.

- **Chores**
    - Enhanced the build script to manage PHP CLI versions and facilitate the conditional installation of SQLite during the Docker build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->