### PR TITLE
Use DDEV method for SQLite to avoid side effects of debian testing

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,13 +6,14 @@ FROM docksal/cli:${CLI_VERSION}
 # See https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+ARG TARGETARCH
 ARG HELM_VERSION=v2.17.0
 # Args defined before the FROM directive are not available in the build stage,
 # so cannot test CLI_VERSION directly here.
 ARG INSTALL_SQLITE=false
 
 # Install kubectl and helm client
-RUN curl -o /usr/local/bin/kubectl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" && \
+RUN curl -o /usr/local/bin/kubectl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
   chmod +x /usr/local/bin/kubectl && \
   curl -o ./install_helm.sh https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
   chmod +x ./install_helm.sh && \
@@ -20,7 +21,7 @@ RUN curl -o /usr/local/bin/kubectl -LO "https://storage.googleapis.com/kubernete
   helm init --client-only
 
 # Also install helm3 as `helm3`
-RUN curl -s https://get.helm.sh/helm-v3.6.2-linux-"$(dpkg --print-architecture)".tar.gz | sudo tar -C /tmp --no-same-owner -xvzf - linux-"$(dpkg --print-architecture)"/helm --strip-components 1 && \
+RUN curl -s https://get.helm.sh/helm-v3.6.2-linux-${TARGETARCH}.tar.gz | sudo tar -C /tmp --no-same-owner -xvzf - linux-${TARGETARCH}/helm --strip-components 1 && \
     mv /tmp/helm /bin/helm3
 
 # Install Kustomize
@@ -39,19 +40,21 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-"$(uname -m)".zip -o "aws
 
 # Install yq
 # https://mikefarah.gitbook.io/yq/#wget
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_"$(dpkg --print-architecture)".tar.gz -O - |\
-  tar xz && mv yq_linux_"$(dpkg --print-architecture)" /usr/bin/yq
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${TARGETARCH}.tar.gz -O - |\
+  tar xz && mv yq_linux_${TARGETARCH} /usr/bin/yq
 
 # Upgrade SQLite 3.x if specified in the build args.
 # @see https://www.drupal.org/project/drupal/issues/3346338
+# @see https://github.com/ddev/ddev/blob/a82397976cb06a440b23a81a474ceda13a428ae1/containers/ddev-webserver/Dockerfile#L124
 # @see https://github.com/docksal/service-cli/pull/327/files
-# Need to get sqlite3 from the Debian testing repository as the default version is too old.
+# Using the DDEV method since it doesn't have the side effects of the Docksal method.
+ARG SQLITE_VERSION="3.45.1"
 RUN if [ "$INSTALL_SQLITE" = "true" ]; then \
-  set -xe; \
-  echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
-  apt-get update >/dev/null; \
-  apt-get install -y -t testing sqlite3; \
-  apt-get clean; rm -rf /var/lib/apt/lists/*; \
+  mkdir -p /tmp/sqlite3; \
+  wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb; \
+  wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb; \
+  apt-get install -y /tmp/sqlite3/*.deb; \
+  rm -rf /tmp/sqlite3; \
 fi
 
 # Install expect, vim


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile to support architecture-specific installations
	- Added ability to specify SQLite version during build process
	- Improved binary download and installation methods for `kubectl`, `helm`, and `yq`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->